### PR TITLE
patch setuptools in pyproj

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "directmultistep"
-version = "1.0.0"
+version = "1.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "numpy==1.26.4",
@@ -20,7 +20,6 @@ dependencies = [
 authors = [
     { name = "Anton Morgunov", email = "anton@ischemist.com" },
     { name = "Yu Shee", email = "yu.shee@yale.edu" },
-    { name = "Haote Li", email = "haote.li@yale.edu" },
 ]
 license = { text = "MIT" }
 readme = "README.md"
@@ -30,7 +29,6 @@ Homepage = "https://github.com/batistagroup/DirectMultiStep"
 Issues = "https://github.com/batistagroup/DirectMultiStep/issues"
 
 [tool.setuptools]
-packages = ["directmultistep"]
 package-dir = { "" = "src" }
 
 


### PR DESCRIPTION
turns out you don't need to specify package name in setuptools block